### PR TITLE
Support JSON responses, GZip and better handling of XML responses

### DIFF
--- a/NScrape/JsonWebResponse.cs
+++ b/NScrape/JsonWebResponse.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Text;
+
+namespace NScrape
+{
+    public class JsonWebResponse : TextWebResponse
+    {
+        internal JsonWebResponse(bool success, Uri url, string text, Encoding encoding)
+            : base(url, WebResponseType.JavaScript, success, text, encoding)
+        {
+        }
+
+        /// <summary>
+        /// Gets the JSON data.
+        /// </summary>
+        public string Json { get { return Text; } }
+    }
+}

--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Forms\BasicHtmlForm.cs" />
     <Compile Include="Forms\TextAreaHtmlFormControl.cs" />
     <Compile Include="JavaScriptWebResponse.cs" />
+    <Compile Include="JsonWebResponse.cs" />
     <Compile Include="NScrapeUtility.cs" />
     <Compile Include="RegexCache.cs" />
     <Compile Include="ScrapeException.cs" />

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -452,6 +452,10 @@ namespace NScrape {
 
 								response = new JavaScriptWebResponse( true, webResponse.ResponseUri, text, encoding );
 							}
+                            else if ( contentType.StartsWith( "application/json", StringComparison.OrdinalIgnoreCase ) ) {
+								var text = ReadResponseText( webResponse, encoding );
+                                response = new JsonWebResponse(true, webResponse.ResponseUri, text, encoding);
+                            }
 							else {
 								response = new UnsupportedWebResponse( contentType, webResponse.ResponseUri );
 							}

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -148,7 +149,14 @@ namespace NScrape {
 			var s = response.GetResponseStream();
 
 			if ( s != null ) {
-				var sr = new StreamReader( s, encoding );
+                StreamReader sr;
+
+                if(response.ContentEncoding == "gzip") {
+                    sr = new StreamReader( new GZipStream(s, CompressionMode.Decompress), encoding );
+                }
+                else { 
+				    sr = new StreamReader( s, encoding );
+                }
 
 				var content = sr.ReadToEnd();
 

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -443,7 +443,8 @@ namespace NScrape {
 									response = new HtmlWebResponse( true, webResponse.ResponseUri, html, encoding );
 								}
 							}
-							else if ( contentType.StartsWith( "text/xml", StringComparison.OrdinalIgnoreCase ) ) {
+							else if ( contentType.StartsWith( "text/xml", StringComparison.OrdinalIgnoreCase)
+                                || contentType.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase)) {
 								var xml = ReadResponseText( webResponse, encoding );
 
 								response = new XmlWebResponse( true, webResponse.ResponseUri, xml, encoding );


### PR DESCRIPTION
This pull requests enables support for responses that contain JSON data, and for responses that have their data encoded using GZIP compression.

JSON is returned by Web APIs so can be pretty useful to support. 

GZIP compression is specified in [RFC 2616 section 3.5](https://tools.ietf.org/html/rfc2616#section-3.5). I've only implemented GZIP - the most popular one, but other compression methods are possible, too.
