### PR TITLE
Enable subclassing of most controls outside of the NScrape assembly

### DIFF
--- a/NScrape/Forms/HtmlForm.cs
+++ b/NScrape/Forms/HtmlForm.cs
@@ -105,7 +105,7 @@ namespace NScrape.Forms {
 			PopulateForm( formDefinition );
 		}
 
-		private Uri ActionUrl {
+		protected Uri ActionUrl {
 			get {
 				if ( Attributes.ContainsKey( "action" ) ) {
 					if ( Uri.IsWellFormedUriString( Attributes["action"], UriKind.Absolute ) ) {
@@ -134,7 +134,7 @@ namespace NScrape.Forms {
 		/// <summary>
 		/// Gets the URL of the page where the form is located.
 		/// </summary>
-		public Uri FormUrl { get; private set; }
+		public Uri FormUrl { get; protected set; }
 
 		/// <summary>
 		/// Gets the HTML text of the page containing the form.
@@ -403,9 +403,11 @@ namespace NScrape.Forms {
 
 			request.IsXmlHttpRequest = SubmitAsXmlHttpRequest;
 
-			request.Headers.Add( CommonHeaders.Referer, FormUrl.ToString() );
+            if (FormUrl != null) {
+                request.Headers.Add(CommonHeaders.Referer, FormUrl.ToString());
+            }
 
 			return WebResponseValidator.ValidateResponse( WebClient.SendRequest( request ), validTypes, string.Format( CultureInfo.CurrentCulture, NScrapeResources.UnexpectedResponseOnFormSubmission, request.Destination ) );
 		}
-	}
+    }
 }

--- a/NScrape/Forms/HtmlFormControl.cs
+++ b/NScrape/Forms/HtmlFormControl.cs
@@ -26,15 +26,29 @@ namespace NScrape.Forms {
 
 			// http://www.w3.org/TR/html4/interact/forms.html#h-17.12.1
 			Disabled = ( Attributes.ContainsKey( "disabled" ) );
-		}
+        }
 
-		/// <summary>
-		/// Gets or sets whether or not the control is disabled.
-		/// </summary>
-		/// <remarks>
-		/// Disabled controls are omitted by <see cref="HtmlForm.BuildRequest"/>.
-		/// </remarks>
-		public bool Disabled { get; set; }
+        /// <summary>
+        /// Adds an individual attribute to the control HTML.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the attribute to add.
+        /// </param>
+        /// <param name="value">
+        /// The attribute value.
+        /// </param>
+        protected void AddAttribute(string name, string value)
+        {
+            attributes.Add(name, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether or not the control is disabled.
+        /// </summary>
+        /// <remarks>
+        /// Disabled controls are omitted by <see cref="HtmlForm.BuildRequest"/>.
+        /// </remarks>
+        public bool Disabled { get; set; }
 
 		/// <summary>
 		/// Gets the value of the control's <b>id</b> attribute.
@@ -56,5 +70,5 @@ namespace NScrape.Forms {
 		/// Gets the value of the control in <b>application/x-www-form-urlencoded</b> format.
 		/// </summary>
 		public abstract string EncodedData { get; }
-	}
+    }
 }

--- a/NScrape/Forms/InputHtmlFormControl.cs
+++ b/NScrape/Forms/InputHtmlFormControl.cs
@@ -9,7 +9,25 @@ namespace NScrape.Forms {
 	/// </summary>
 	public class InputHtmlFormControl : HtmlFormControl {
 
-		internal InputHtmlFormControl( string html ) {
+        /// <summary>
+        /// Initialzes a new instance of the <see cref="InputHtmlFormControl"/> class.
+        /// </summary>
+        /// <param name="type">
+        /// The control type to create.
+        /// </param>
+        /// <param name="name">
+        /// The name of the control.
+        /// </param>
+        /// <param name="value">
+        /// The control value.
+        /// </param>
+        public InputHtmlFormControl( InputHtmlFormControlType type, string name, string value ) {
+            ControlType = type;
+            AddAttribute("name", name);
+            AddAttribute("value", value);
+        }
+
+        internal InputHtmlFormControl( string html ) {
 			var match = RegexCache.Instance.Regex( RegexLibrary.ParseInput, RegexLibrary.ParseInputOptions ).Match( html );
 
 			if ( match.Success ) {

--- a/NScrape/Forms/InputHtmlFormControl.cs
+++ b/NScrape/Forms/InputHtmlFormControl.cs
@@ -64,5 +64,16 @@ namespace NScrape.Forms {
 		/// Gets or sets the value of the control.
 		/// </summary>
 		public string Value { get; set; }
-	}
+
+        /// <summary>
+        /// Gets a <see cref="string"/> that represents the current <see cref="InputHtmlFormControl"/>
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the current <see cref="InputHtmlFormControl"/>.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"{this.Name}: {this.Value} ({this.ControlType})";
+        }
+    }
 }

--- a/NScrape/WebResponseValidator.cs
+++ b/NScrape/WebResponseValidator.cs
@@ -1,5 +1,5 @@
 namespace NScrape {
-	internal static class WebResponseValidator {
+	public static class WebResponseValidator {
 
 		public static HtmlWebResponse ValidateHtmlResponse( WebResponse response, string message ) {
 			return ValidateResponse( response, WebResponseType.Html, message ) as HtmlWebResponse;


### PR DESCRIPTION
I mainly use NScrape to scrape a form, populate some values and then submit the form.

However, in some scenarios, I just want to hand-code the form myself. That is, I subclass the `BasicHtmlForm` class, add some controls to the form in the constructor, set the `ActionUrl` and submit the form myself.

It's fairly easy to do but some of the classes I required were marked `internal` or the fields were `private`. This pull requests makes some fields/classes less protected, and enables that scenario for me.
