### PR TITLE
Extensibility model for content types

### DIFF
--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -27,6 +27,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\NScrape.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -130,6 +130,7 @@
     <Compile Include="WebRequest.cs" />
     <Compile Include="WebRequestType.cs" />
     <Compile Include="WebResponse.cs" />
+    <Compile Include="WebResponseFactory.cs" />
     <Compile Include="WebResponseType.cs" />
     <Compile Include="WebResponseValidator.cs" />
     <Compile Include="XmlWebResponse.cs" />

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -144,22 +144,6 @@ namespace NScrape {
 			}
 		}
 
-		private static string ReadResponseText( HttpWebResponse response, Encoding encoding ) {
-			var s = response.GetResponseStream();
-
-			if ( s != null ) {
-				var sr = new StreamReader( s, encoding );
-
-				var content = sr.ReadToEnd();
-
-				sr.Close();
-
-				return content;
-			}
-
-			return null;
-		}
-
         /// <summary>
         /// Sends a GET request.
         /// </summary>
@@ -382,28 +366,12 @@ namespace NScrape {
 						// We have a regular response.
 
 						var contentType = webResponse.Headers[CommonHeaders.ContentType];
+                        response = WebResponseFactory.CreateResponse(webResponse, contentType);
 
-						if ( contentType.StartsWith( "image/", StringComparison.OrdinalIgnoreCase ) ) {
-							var image = new Bitmap( 0, 0 );
-
-							var s = webResponse.GetResponseStream();
-
-							if ( s != null ) {
-								image = new Bitmap( s );
-							}
-
-							response = new ImageWebResponse( true, webResponse.ResponseUri, image );
-						}
-						else {
-							// If a character set is not specified, RFC2616 section 3.7.1 says to use ISO-8859-1, per the page below.
-							// The page says this is more or less useless, but I did find that Chrome and Firefox behaved this way
-							// for javascript files that I tested.
-							// http://www.w3.org/TR/html4/charset.html#h-5.2.2
-							var characterSet = ( !string.IsNullOrEmpty( webResponse.CharacterSet ) ? webResponse.CharacterSet : "iso-8859-1" );
-							var encoding = Encoding.GetEncoding( characterSet );
-
+                        if(response == null) {
 							if ( contentType.StartsWith( "text/html", StringComparison.OrdinalIgnoreCase ) ) {
-								var html = ReadResponseText( webResponse, encoding );
+                                var encoding = WebResponseFactory.GetEncoding( webResponse );
+								var html = WebResponseFactory.ReadResponseText( webResponse, encoding );
 
 								var haveRefresh = false;
 
@@ -434,23 +402,6 @@ namespace NScrape {
 									// Just a regular Html page
 									response = new HtmlWebResponse( true, webResponse.ResponseUri, html, encoding );
 								}
-							}
-							else if ( contentType.StartsWith( "text/xml", StringComparison.OrdinalIgnoreCase ) ) {
-								var xml = ReadResponseText( webResponse, encoding );
-
-								response = new XmlWebResponse( true, webResponse.ResponseUri, xml, encoding );
-							}
-							else if ( contentType.StartsWith( "text/plain", StringComparison.OrdinalIgnoreCase ) ) {
-								var text = ReadResponseText( webResponse, encoding );
-
-								response = new PlainTextWebResponse( true, webResponse.ResponseUri, text, encoding );
-							}
-							// Javascript might be specified in a few ways
-							// http://stackoverflow.com/a/1998417
-							else if ( contentType.Contains( "javascript" ) ) {
-								var text = ReadResponseText( webResponse, encoding );
-
-								response = new JavaScriptWebResponse( true, webResponse.ResponseUri, text, encoding );
 							}
 							else {
 								response = new UnsupportedWebResponse( contentType, webResponse.ResponseUri );

--- a/NScrape/WebResponseFactory.cs
+++ b/NScrape/WebResponseFactory.cs
@@ -27,6 +27,8 @@ namespace NScrape
             SupportedContentTypes.Add("application/javascript ", CreateJavaScriptResponse);
             SupportedContentTypes.Add("application/x-javascript", CreateJavaScriptResponse);
             SupportedContentTypes.Add("application/json", CreateJsonResponse);
+
+            SupportedContentTypes = new Dictionary<string, Func<HttpWebResponse, WebResponse>>();
         }
 
         /// <summary>
@@ -37,8 +39,10 @@ namespace NScrape
         /// object with the given content type and returns a <see cref="WebResponse"/>. The return value
         /// is usually a subclass of the <see cref="WebResponse"/> class.
         /// </summary>
-        public static Dictionary<string, Func<HttpWebResponse, WebResponse>> SupportedContentTypes
-        { get; } = new Dictionary<string, Func<HttpWebResponse, WebResponse>>();
+        public static Dictionary<string, Func<HttpWebResponse, WebResponse>> SupportedContentTypes {
+            get;
+            private set;
+        }
 
         /// <summary>
         /// Creates a <see cref="ImageWebResponse"/>.

--- a/NScrape/WebResponseFactory.cs
+++ b/NScrape/WebResponseFactory.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace NScrape
+{
+    /// <summary>
+    /// Creates a <see cref="WebResponse"/> object based on a <see cref="HttpWebResponse"/> object.
+    /// </summary>
+    public class WebResponseFactory
+    {
+        /// <summary>
+        /// Initializes static members of the <see cref="WebResponseFactory"/> class.
+        /// </summary>
+        static WebResponseFactory()
+        {
+            SupportedContentTypes.Add("image/", CreateImageResponse);
+            SupportedContentTypes.Add("text/xml", CreateXmlResponse);
+            SupportedContentTypes.Add("text/plain", CreateTextResponse);
+            SupportedContentTypes.Add("text/javascript", CreateJavaScriptResponse);
+            SupportedContentTypes.Add("application/javascript ", CreateJavaScriptResponse);
+            SupportedContentTypes.Add("application/x-javascript", CreateJavaScriptResponse);
+        }
+
+        /// <summary>
+        /// Gets a dictionary that contains all content types that are currently suported by the
+        /// <see cref="WebResponseFactory"/>. The key of the dictionary is the text the content type
+        /// must start with (but not necessarily the full text of the content type); the value is a
+        /// <see cref="Func{HttpWebResponse, WebResponse}"/> that takes a <see cref="HttpWebResponse"/>
+        /// object with the given content type and returns a <see cref="WebResponse"/>. The return value
+        /// is usually a subclass of the <see cref="WebResponse"/> class.
+        /// </summary>
+        public static Dictionary<string, Func<HttpWebResponse, WebResponse>> SupportedContentTypes
+        { get; } = new Dictionary<string, Func<HttpWebResponse, WebResponse>>();
+
+        /// <summary>
+        /// Creates a <see cref="ImageWebResponse"/>.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The original <see cref="HttpWebResponse"/>.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="ImageWebResponse"/>.
+        /// </returns>
+        public static WebResponse CreateImageResponse(HttpWebResponse webResponse)
+        {
+            var image = new Bitmap(0, 0);
+
+            var s = webResponse.GetResponseStream();
+
+            if (s != null)
+            {
+                image = new Bitmap(s);
+            }
+
+            return new ImageWebResponse(true, webResponse.ResponseUri, image);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PlainTextWebResponse"/>.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The original <see cref="HttpWebResponse"/>.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="PlainTextWebResponse"/>.
+        /// </returns>
+        public static WebResponse CreateTextResponse(HttpWebResponse webResponse)
+        {
+            var encoding = GetEncoding(webResponse);
+            var text = ReadResponseText(webResponse, encoding);
+            return new PlainTextWebResponse(true, webResponse.ResponseUri, text, encoding);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="XmlWebResponse"/>.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The original <see cref="HttpWebResponse"/>.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="XmlWebResponse"/>.
+        /// </returns>
+        public static WebResponse CreateXmlResponse(HttpWebResponse webResponse)
+        {
+            var encoding = GetEncoding(webResponse);
+            var xml = ReadResponseText(webResponse, encoding);
+            return new XmlWebResponse(true, webResponse.ResponseUri, xml, encoding);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="JavaScriptWebResponse"/>.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The original <see cref="HttpWebResponse"/>.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="JavaScriptWebResponse"/>.
+        /// </returns>
+        public static WebResponse CreateJavaScriptResponse(HttpWebResponse webResponse)
+        {
+            var encoding = GetEncoding(webResponse);
+            var javaScript = ReadResponseText(webResponse, encoding);
+            return new JavaScriptWebResponse(true, webResponse.ResponseUri, javaScript, encoding);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="WebResponse"/> for a <see cref="HttpWebResponse"/>, based on its
+        /// content type. If the content type is not registered with the <see cref="WebResponseFactory"/>,
+        /// returns <see langword="null"/>.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The <see cref="HttpWebResponse"/> to parse.
+        /// </param>
+        /// <param name="contentType">
+        /// The content type of the web response.
+        /// </param>
+        /// <returns>
+        /// If the content type is registered with the <see cref="WebResponseFactory"/>, a new
+        /// <see cref="WebResponse"/> object. Else, <see langword="null"/>.
+        /// </returns>
+        public static WebResponse CreateResponse(HttpWebResponse webResponse, string contentType)
+        {
+            // The keys in the SupportedContentTypes indicate the text the contentType
+            // must start with. Find that key
+            var key = SupportedContentTypes.Keys.SingleOrDefault(k => contentType.StartsWith(k, StringComparison.OrdinalIgnoreCase));
+
+            // We don't support this content type
+            if( key == null ) {
+                return null;
+            }
+            else {
+                return SupportedContentTypes[key]( webResponse );
+            }
+        }
+
+        /// <summary>
+        /// Gets the encoding used by a <see cref="HttpWebResponse"/>. Falls back to the <c>iso-8859-1</c>
+        /// character set if no encoding was specified.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The <see cref="HttpWebResponse"/> for which to determine the content type.
+        /// </param>
+        /// <returns>
+        /// The content type used by the <see cref="HttpWebResponse"/>.
+        /// </returns>
+        public static Encoding GetEncoding(HttpWebResponse webResponse)
+        {
+            // If a character set is not specified, RFC2616 section 3.7.1 says to use ISO-8859-1, per the page below.
+            // The page says this is more or less useless, but I did find that Chrome and Firefox behaved this way
+            // for javascript files that I tested.
+            // http://www.w3.org/TR/html4/charset.html#h-5.2.2
+            var characterSet = (!string.IsNullOrEmpty(webResponse.CharacterSet) ? webResponse.CharacterSet : "iso-8859-1");
+            return Encoding.GetEncoding(characterSet);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="HttpWebResponse"/> as plain text.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The <see cref="HttpWebResponse"/> to read.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that represents the text of a <see cref="HttpWebResponse"/>.
+        /// </returns>
+        public static string ReadResponseText(HttpWebResponse webResponse)
+        {
+            var encoding = GetEncoding(webResponse);
+            return ReadResponseText(webResponse, encoding);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="HttpWebResponse"/> as plain text.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The <see cref="HttpWebResponse"/> to read.
+        /// </param>
+        /// <param name="encoding">
+        /// The encoding used.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that represents the text of a <see cref="HttpWebResponse"/>.
+        /// </returns>
+        public static string ReadResponseText(HttpWebResponse webResponse, Encoding encoding)
+        {
+            var s = webResponse.GetResponseStream();
+
+            if (s != null)
+            {
+                var sr = new StreamReader(s, encoding);
+
+                var content = sr.ReadToEnd();
+
+                sr.Close();
+
+                return content;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This pull requests implements an extensibility model for content types.

For example, if you want to add another content type that supports XML, you could do:

```
WebResponsFactory.SupportedContentTypes.Add("application/xml", WebResponseFactory.CreateXmlResponse);
```

There are, no doubt, tons of other ways of doing this, but it works for me.

The `HTML` responses are still hard coded; because they process the `<META>` tag and can trigger refreshes they were a bit of a special case.
