### PR TITLE
Enable mocking of the WebClient

### DIFF
--- a/NScrape/ExceptionWebResponse.cs
+++ b/NScrape/ExceptionWebResponse.cs
@@ -8,7 +8,7 @@ namespace NScrape {
     public class ExceptionWebResponse : WebResponse {
         private readonly WebException exception;
 
-        internal ExceptionWebResponse( WebException exception, Uri url )
+        public ExceptionWebResponse( WebException exception, Uri url )
             : base( url, WebResponseType.Exception, false ) {
             this.exception = exception;
         }

--- a/NScrape/Forms/BasicAspxForm.cs
+++ b/NScrape/Forms/BasicAspxForm.cs
@@ -11,7 +11,7 @@
 		/// Initializes a new instance of the <see cref="BasicAspxForm"/> class.
 		/// </summary>
 		/// <param name="webClient">Contains the web client to be used to request and submit the form.</param>
-		public BasicAspxForm( WebClient webClient )
+		public BasicAspxForm( IWebClient webClient )
 			: base( webClient ) {
 		}
 

--- a/NScrape/Forms/BasicForm.cs
+++ b/NScrape/Forms/BasicForm.cs
@@ -24,7 +24,7 @@ namespace NScrape.Forms {
 		/// Initializes a new instance of the <see cref="BasicForm"/> class.
 		/// </summary>
 		/// <param name="webClient">Contains the web client to be used to request and submit the form.</param>
-		protected BasicForm( WebClient webClient )
+		protected BasicForm( IWebClient webClient )
 			: base( webClient ) {
 		}
 

--- a/NScrape/Forms/BasicHtmlForm.cs
+++ b/NScrape/Forms/BasicHtmlForm.cs
@@ -11,7 +11,7 @@
 		/// Initializes a new instance of the <see cref="BasicHtmlForm"/> class.
 		/// </summary>
 		/// <param name="webClient">Contains the web client to be used to request and submit the form.</param>
-		public BasicHtmlForm( WebClient webClient )
+		public BasicHtmlForm( IWebClient webClient )
 			: base( webClient ) {
 		}
 

--- a/NScrape/Forms/HtmlForm.cs
+++ b/NScrape/Forms/HtmlForm.cs
@@ -17,7 +17,7 @@ namespace NScrape.Forms {
 		/// Initializes a new instance of the <see cref="HtmlForm"/> class.
 		/// </summary>
 		/// <param name="webClient">Contains the web client to be used to request and submit the form.</param>
-		protected HtmlForm( WebClient webClient ) {
+		protected HtmlForm( IWebClient webClient ) {
 			WebClient = webClient;
 
 			Attributes = new Dictionary<string, string>( StringComparer.OrdinalIgnoreCase );
@@ -144,7 +144,7 @@ namespace NScrape.Forms {
 		/// <summary>
 		/// Gets the web client used to request and submit the form.
 		/// </summary>
-		protected WebClient WebClient { get; private set; }
+		protected IWebClient WebClient { get; private set; }
 
 		/// <summary>
 		/// Builds the request data to be used to submit an ASPX form.

--- a/NScrape/GetWebRequest.cs
+++ b/NScrape/GetWebRequest.cs
@@ -31,5 +31,16 @@ namespace NScrape {
             : this( destination ) {
             AutoRedirect = autoRedirect;
         }
+
+        /// <summary>
+        /// Gets a <see cref="string"/> that represents the current <see cref="GetWebRequest"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the current <see cref="GetWebRequest"/>.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"GET {this.Destination}";
+        }
     }
 }

--- a/NScrape/HtmlWebResponse.cs
+++ b/NScrape/HtmlWebResponse.cs
@@ -7,7 +7,7 @@ namespace NScrape {
 	/// </summary>
     public class HtmlWebResponse : TextWebResponse {
 
-        internal HtmlWebResponse( bool success, Uri url, string html, Encoding encoding )
+        public HtmlWebResponse( bool success, Uri url, string html, Encoding encoding )
             : base( url, WebResponseType.Html, success, html, encoding ) {
         }
 

--- a/NScrape/IWebClient.cs
+++ b/NScrape/IWebClient.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Net;
+
+namespace NScrape
+{
+    /// <summary>
+    /// Represents a web client that handles cookies and redirection.
+    /// </summary>
+    public interface IWebClient
+    {
+        /// <include file='IWebClient.xml' path='/IWebClient/AddingCookie'/>
+		event EventHandler<AddingCookieEventArgs> AddingCookie;
+
+        /// <include file='IWebClient.xml' path='/IWebClient/SendingRequest'/>
+        event EventHandler<SendingRequestEventArgs> SendingRequest;
+
+        /// <include file='IWebClient.xml' path='/IWebClient/CookieJar'/>
+        CookieContainer CookieJar { get; }
+
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri'/>
+        WebResponse SendRequest(Uri destination);
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri_bool'/>
+        WebResponse SendRequest(Uri destination, bool autoRedirect);
+
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri_string'/>
+        WebResponse SendRequest(Uri destination, string requestData);
+
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri_string_bool'/>
+        WebResponse SendRequest(Uri destination, string requestData, bool autoRedirect);
+
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_WebRequest'/>
+        WebResponse SendRequest(WebRequest webRequest);
+
+        /// <include file='IWebClient.xml' path='/IWebClient/UserAgent'/>
+        string UserAgent { get; set; }
+    }
+}
+

--- a/NScrape/IWebClient.xml
+++ b/NScrape/IWebClient.xml
@@ -1,0 +1,177 @@
+﻿<IWebClient>
+  <AddingCookie>
+    <summary>
+      Occurs when a cookie is added to the <see cref="CookieJar"/>.
+    </summary>
+    <remarks>
+      As the <see cref="WebClient"/> executes requests and receives cookies from the server in response, it stores
+      them in its cookie jar (a <see cref="CookieContainer"/>) and sends them along on subsequent requests.
+    </remarks>
+    <seealso cref="CookieJar"/>
+    <seealso cref="AddingCookieEventArgs"/>
+  </AddingCookie>
+
+  <SendingRequest>
+    <summary>
+      Occurs when a request is being sent.
+    </summary>
+    <remarks>
+      Use this event to be notified when the <see cref="WebClient"/> sends a request.
+    </remarks>
+    <seealso cref="SendingRequestEventArgs"/>
+  </SendingRequest>
+
+  <CookieJar>
+    <summary>
+      Gets the cookies that have been collected by the <see cref="WebClient"/> in the course of executing requests.
+    </summary>
+    <remarks>
+      As the <see cref="WebClient"/> executes requests and receives cookies from the server in response, it stores
+      them in its cookie jar (a <see cref="CookieContainer"/>) and sends them along on subsequent requests.
+      <br/><br/>
+      To be notified when a cookie is added to the jar, subscribe to the <see cref="AddingCookie"/> event.
+    </remarks>
+    <seealso cref="AddingCookie"/>
+  </CookieJar>
+
+  <SendRequest_Uri>
+    <summary>
+      Sends a GET request.
+    </summary>
+    <param name="destination">Specifies the destination of the request.</param>
+    <remarks>
+      Sends a GET request that shall be automatically redirected if applicable.
+    </remarks>
+    <returns>The response from the server.</returns>
+    <example>
+      <code>
+        var webClient = new WebClient();
+
+        var uri = new Uri( "http://www.foo.com" );
+
+        var response = webClient.SendRequest( uri );
+      </code>
+    </example>
+    <seealso cref="WebResponse"/>
+  </SendRequest_Uri>
+
+  <SendRequest_Uri_bool>
+    <summary>
+      Sends a GET request, specifying redirection.
+    </summary>
+    <param name="destination">Specifies the destination of the request.</param>
+    <param name="autoRedirect">
+      <b>true</b> if the request should be automatically redirected; <b>false</b> otherwise.
+    </param>
+    <remarks>
+      Sends a GET request, specifying whether the request shall be automatically redirected if applicable.
+    </remarks>
+    <returns>The response from the server.</returns>
+    <example>
+      <code>
+        var webClient = new WebClient();
+
+        var uri = new Uri( "http://www.foo.com" );
+
+        var response = webClient.SendRequest( uri, false );
+      </code>
+    </example>
+    <seealso cref="WebResponse"/>
+  </SendRequest_Uri_bool>
+
+  <SendRequest_Uri_string>
+    <summary>
+      Sends a POST request.
+    </summary>
+    <param name="destination">Specifies the destination of the request.</param>
+    <param name="requestData">
+      Contains the request data in <b>application/x-www-form-urlencoded</b> format.
+    </param>
+    <remarks>
+      Sends a POST request that shall be automatically redirected if applicable.
+    </remarks>
+    <returns>The response from the server.</returns>
+    <example>
+      <code>
+        var webClient = new WebClient();
+
+        var uri = new Uri( "http://www.foo.com" );
+        var data = "step=confirmation&amp;rt=L&amp;rp=%2Flogin%2Fhome&amp;p=0&amp;inputEmailHandle=foo&amp;inputPassword=bar";
+
+        var response = webClient.SendRequest( uri, data );
+      </code>
+    </example>
+    <returns>The response from the server.</returns>
+    <seealso cref="WebResponse"/>
+  </SendRequest_Uri_string>
+
+  <SendRequest_Uri_string_bool>
+    <summary>
+      Sends a POST request, specifying redirection.
+    </summary>
+    <param name="destination">Specifies the destination of the request.</param>
+    <param name="requestData">
+      Contains the request data in <b>application/x-www-form-urlencoded</b> format.
+    </param>
+    <param name="autoRedirect">
+      <b>true</b> if the request should be automatically redirected; <b>false</b> otherwise.
+    </param>
+    <remarks>
+      Sends a POST request, specifying whether the request shall be automatically redirected if applicable.
+    </remarks>
+    <returns>The response from the server.</returns>
+    <example>
+      <code>
+        var webClient = new WebClient();
+
+        var uri = new Uri( "http://www.foo.com" );
+        var data = "step=confirmation&amp;rt=L&amp;rp=%2Flogin%2Fhome&amp;p=0&amp;inputEmailHandle=foo&amp;inputPassword=bar";
+
+        var response = webClient.SendRequest( uri, data, false );
+      </code>
+    </example>
+    <returns>The response from the server.</returns>
+    <seealso cref="WebResponse"/>
+  </SendRequest_Uri_string_bool>
+
+  <SendRequest_WebRequest>
+    <summary>
+      Sends a GET or POST request.
+    </summary>
+    <param name="webRequest">The request to send.</param>
+    <remarks>
+      Sends a GET or POST request.
+    </remarks>
+    <returns>The response from the server.</returns>
+    <example>
+      <code>
+        var webClient = new WebClient();
+
+        var request = new PostWebRequest() {
+        Destination = new Uri( "http://www.foo.com" ),
+        RequestData = "step=confirmation&amp;rt=L&amp;rp=%2Flogin%2Fhome&amp;p=0&amp;inputEmailHandle=foo&amp;inputPassword=bar"
+        };
+
+        var response = webClient.SendRequest( request );
+      </code>
+    </example>
+    <seealso cref="WebRequest"/>
+    <seealso cref="WebResponse"/>
+  </SendRequest_WebRequest>
+
+  <UserAgent>
+    <summary>
+      Gets or sets the user agent for requests made by a <see cref="WebClient"/>.
+    </summary>
+    <remarks>
+      If the user agent is not explicitly set, it defaults to a string of the form: <code>NScrape/[version] (+https://github.com/darrylwhitmore/NScrape)</code>
+    </remarks>
+    <example>
+      <code>
+        var webClient = new WebClient {
+        UserAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko"
+        };
+      </code>
+    </example>
+  </UserAgent>
+</IWebClient>

--- a/NScrape/ImageWebResponse.cs
+++ b/NScrape/ImageWebResponse.cs
@@ -8,7 +8,7 @@ namespace NScrape {
     public class ImageWebResponse : WebResponse {
         private readonly Bitmap image;
 
-        internal ImageWebResponse( bool success, Uri url, Bitmap image )
+        public ImageWebResponse( bool success, Uri url, Bitmap image )
             : base( url, WebResponseType.Image, success ) {
             this.image = image;
         }

--- a/NScrape/JavaScriptWebResponse.cs
+++ b/NScrape/JavaScriptWebResponse.cs
@@ -7,7 +7,7 @@ namespace NScrape {
 	/// </summary>
     public class JavaScriptWebResponse : TextWebResponse {
 
-		internal JavaScriptWebResponse( bool success, Uri url, string text, Encoding encoding )
+		public JavaScriptWebResponse( bool success, Uri url, string text, Encoding encoding )
             : base( url, WebResponseType.JavaScript, success, text, encoding ) {
         }
 

--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Forms\BasicForm.cs" />
     <Compile Include="Forms\BasicHtmlForm.cs" />
     <Compile Include="Forms\TextAreaHtmlFormControl.cs" />
+    <Compile Include="IWebClient.cs" />
     <Compile Include="JavaScriptWebResponse.cs" />
     <Compile Include="NScrapeUtility.cs" />
     <Compile Include="RegexCache.cs" />
@@ -143,6 +144,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="IWebClient.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/NScrape/PlaintextWebResponse.cs
+++ b/NScrape/PlaintextWebResponse.cs
@@ -7,7 +7,7 @@ namespace NScrape {
 	/// </summary>
     public class PlainTextWebResponse : TextWebResponse {
 
-        internal PlainTextWebResponse( bool success, Uri url, string text, Encoding encoding )
+        public PlainTextWebResponse( bool success, Uri url, string text, Encoding encoding )
             : base( url, WebResponseType.PlainText, success, text, encoding ) {
         }
 

--- a/NScrape/PostWebRequest.cs
+++ b/NScrape/PostWebRequest.cs
@@ -111,5 +111,16 @@ namespace NScrape {
         /// Gets or sets the request data.
         /// </summary>
         public string RequestData { get { return requestData; } set { requestData = value; } }
+
+        /// <summary>
+        /// Gets a <see cref="string"/> that represents the current <see cref="PostWebRequest"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the current <see cref="PostWebRequest"/>.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"POST {this.Destination}";
+        }
     }
 }

--- a/NScrape/RedirectedWebResponse.cs
+++ b/NScrape/RedirectedWebResponse.cs
@@ -9,7 +9,7 @@ namespace NScrape {
         private readonly WebRequest request;
         private readonly Uri redirectUrl;
 
-        internal RedirectedWebResponse( Uri url, WebRequest request, Uri redirectUrl )
+        public RedirectedWebResponse( Uri url, WebRequest request, Uri redirectUrl )
             : base( url, WebResponseType.Redirect, true ) {
             this.request = request;
             this.redirectUrl = redirectUrl;

--- a/NScrape/TextWebResponse.cs
+++ b/NScrape/TextWebResponse.cs
@@ -17,7 +17,7 @@ namespace NScrape {
 		/// <param name="success"><b>true</b> if the response is considered successful, <b>false</b> otherwise.</param>
 		/// <param name="text">The text of the response.</param>
         /// <param name="encoding">The encoding of the text.</param>
-        protected TextWebResponse( Uri responseUrl, WebResponseType responseType, bool success, string text, Encoding encoding )
+        public TextWebResponse( Uri responseUrl, WebResponseType responseType, bool success, string text, Encoding encoding )
             : base( responseUrl, responseType, success ) {
             this.text = text;
             this.encoding = encoding;

--- a/NScrape/UnsupportedWebResponse.cs
+++ b/NScrape/UnsupportedWebResponse.cs
@@ -7,7 +7,7 @@ namespace NScrape {
     public class UnsupportedWebResponse : WebResponse {
         private readonly string contentType;
 
-        internal UnsupportedWebResponse( string contentType, Uri responseUrl )
+        public UnsupportedWebResponse( string contentType, Uri responseUrl )
             : base( responseUrl, WebResponseType.Unsupported, false ) {
             this.contentType = contentType;
         }

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -11,28 +11,12 @@ namespace NScrape {
 	/// <summary>
 	/// Represents a web client that handles cookies and redirection.
 	/// </summary>
-	public class WebClient {
-        /// <summary>
-		/// Occurs when a cookie is added to the <see cref="CookieJar"/>.
-        /// </summary>
-        /// <remarks>
-		/// As the <see cref="WebClient"/> executes requests and receives cookies from the server in response, it stores
-		/// them in its cookie jar (a <see cref="CookieContainer"/>) and sends them along on subsequent requests.
-		/// </remarks>
-		/// <seealso cref="CookieJar"/>
-		/// <seealso cref="OnAddingCookie"/>
-		/// <seealso cref="AddingCookieEventArgs"/>
+	public class WebClient : IWebClient {
+        /// <include file='IWebClient.xml' path='/IWebClient/AddingCookie'/>
 		public event EventHandler<AddingCookieEventArgs> AddingCookie;
 
-		/// <summary>
-		/// Occurs when a request is being sent.
-		/// </summary>
-		/// <remarks>
-		/// Use this event to be notified when the <see cref="WebClient"/> sends a request.
-		/// </remarks>
-		/// <seealso cref="OnSendingRequest"/>
-		/// <seealso cref="SendingRequestEventArgs"/>
-		public event EventHandler<SendingRequestEventArgs> SendingRequest;
+        /// <include file='IWebClient.xml' path='/IWebClient/SendingRequest'/>
+        public event EventHandler<SendingRequestEventArgs> SendingRequest;
 
 	    private readonly HttpStatusCode[] redirectionStatusCodes = {
 		    HttpStatusCode.Moved,				// 301
@@ -103,17 +87,8 @@ namespace NScrape {
 			}
 		}
 
-		/// <summary>
-		/// Gets the cookies that have been collected by the <see cref="WebClient"/> in the course of executing requests.
-		/// </summary>
-		/// <remarks>
-		/// As the <see cref="WebClient"/> executes requests and receives cookies from the server in response, it stores
-		/// them in its cookie jar (a <see cref="CookieContainer"/>) and sends them along on subsequent requests.
-		/// <br/><br/>
-		/// To be notified when a cookie is added to the jar, subscribe to the <see cref="AddingCookie"/> event.
-		/// </remarks>
-		/// <seealso cref="AddingCookie"/>
-		public CookieContainer CookieJar { get { return cookieJar; } }
+        /// <include file='IWebClient.xml' path='/IWebClient/CookieJar'/>
+        public CookieContainer CookieJar { get { return cookieJar; } }
 
 		/// <summary>
 		/// Raises the <see cref="AddingCookie"/> event.
@@ -160,125 +135,28 @@ namespace NScrape {
 			return null;
 		}
 
-        /// <summary>
-        /// Sends a GET request.
-        /// </summary>
-        /// <param name="destination">Specifies the destination of the request.</param>
-        /// <remarks>
-        /// Sends a GET request that shall be automatically redirected if applicable. 
-        /// </remarks>
-        /// <returns>The response from the server.</returns>
-		/// <example>
-		/// <code>
-		///	var webClient = new WebClient();
-		/// 
-		///	var uri = new Uri( "http://www.foo.com" );
-		///
-		///	var response = webClient.SendRequest( uri );
-		/// </code>
-		/// </example>
-		/// <seealso cref="WebResponse"/>
-		public WebResponse SendRequest( Uri destination ) {
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri'/>
+        public WebResponse SendRequest( Uri destination ) {
             return SendRequest( new GetWebRequest( destination ) );
         }
 
-        /// <summary>
-		/// Sends a GET request, specifying redirection.
-		/// </summary>
-		/// <param name="destination">Specifies the destination of the request.</param>
-		/// <param name="autoRedirect"><b>true</b> if the request should be automatically redirected; <b>false</b> otherwise.</param>
-		/// <remarks>
-		/// Sends a GET request, specifying whether the request shall be automatically redirected if applicable. 
-		/// </remarks>
-		/// <returns>The response from the server.</returns>
-		/// <example>
-		/// <code>
-		///	var webClient = new WebClient();
-		/// 
-		///	var uri = new Uri( "http://www.foo.com" );
-		///
-		///	var response = webClient.SendRequest( uri, false );
-		/// </code>
-		/// </example>
-		/// <seealso cref="WebResponse"/>
-		public WebResponse SendRequest( Uri destination, bool autoRedirect ) {
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri_bool'/>
+        public WebResponse SendRequest( Uri destination, bool autoRedirect ) {
             return SendRequest( new GetWebRequest( destination, autoRedirect ) );
         }
 
-        /// <summary>
-		/// Sends a POST request.
-		/// </summary>
-		/// <param name="destination">Specifies the destination of the request.</param>
-		/// <param name="requestData">Contains the request data in <b>application/x-www-form-urlencoded</b> format.</param>
-		/// <remarks>
-		/// Sends a POST request that shall be automatically redirected if applicable.
-		/// </remarks>
-		/// <returns>The response from the server.</returns>
-		/// <example>
-		/// <code>
-		/// var webClient = new WebClient();
-		/// 
-		/// var uri = new Uri( "http://www.foo.com" );
-		/// var data = "step=confirmation&amp;rt=L&amp;rp=%2Flogin%2Fhome&amp;p=0&amp;inputEmailHandle=foo&amp;inputPassword=bar";
-		/// 
-		/// var response = webClient.SendRequest( uri, data );
-		/// </code>
-		/// </example>
-		/// <returns>The response from the server.</returns>
-		/// <seealso cref="WebResponse"/>
-		public WebResponse SendRequest( Uri destination, string requestData ) {
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri_string'/>
+        public WebResponse SendRequest( Uri destination, string requestData ) {
             return SendRequest( new PostWebRequest( destination, requestData ) );
         }
 
-		/// <summary>
-		/// Sends a POST request, specifying redirection.
-		/// </summary>
-		/// <param name="destination">Specifies the destination of the request.</param>
-		/// <param name="requestData">Contains the request data in <b>application/x-www-form-urlencoded</b> format.</param>
-		/// <param name="autoRedirect"><b>true</b> if the request should be automatically redirected; <b>false</b> otherwise.</param>
-		/// <remarks>
-		/// Sends a POST request, specifying whether the request shall be automatically redirected if applicable. 
-		/// </remarks>
-		/// <returns>The response from the server.</returns>
-		/// <example>
-		/// <code>
-		/// var webClient = new WebClient();
-		/// 
-		/// var uri = new Uri( "http://www.foo.com" );
-		/// var data = "step=confirmation&amp;rt=L&amp;rp=%2Flogin%2Fhome&amp;p=0&amp;inputEmailHandle=foo&amp;inputPassword=bar";
-		/// 
-		/// var response = webClient.SendRequest( uri, data, false );
-		/// </code>
-		/// </example>
-		/// <returns>The response from the server.</returns>
-		/// <seealso cref="WebResponse"/>
-		public WebResponse SendRequest( Uri destination, string requestData, bool autoRedirect ) {
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_Uri_string_bool'/>
+        public WebResponse SendRequest( Uri destination, string requestData, bool autoRedirect ) {
             return SendRequest( new PostWebRequest( destination, requestData, autoRedirect ) );
         }
 
-        /// <summary>
-		/// Sends a GET or POST request.
-		/// </summary>
-        /// <param name="webRequest">The request to send.</param>
-		/// <remarks>
-		/// Sends a GET or POST request. 
-		/// </remarks>
-		/// <returns>The response from the server.</returns>
-		/// <example>
-		/// <code>
-		///	var webClient = new WebClient();
-		///	
-		///	var request = new PostWebRequest() {
-		///		Destination = new Uri( "http://www.foo.com" ),
-		///		RequestData = "step=confirmation&amp;rt=L&amp;rp=%2Flogin%2Fhome&amp;p=0&amp;inputEmailHandle=foo&amp;inputPassword=bar"
-		///	};
-		///
-		///	var response = webClient.SendRequest( request );
-		/// </code>
-		/// </example>
-		/// <seealso cref="WebRequest"/>
-		/// <seealso cref="WebResponse"/>
-		public WebResponse SendRequest( WebRequest webRequest ) {
+        /// <include file='IWebClient.xml' path='/IWebClient/SendRequest_WebRequest'/>
+        public WebResponse SendRequest( WebRequest webRequest ) {
             var httpWebRequest = (HttpWebRequest)System.Net.WebRequest.Create( webRequest.Destination );
 
 			httpWebRequest.Method = webRequest.Type.ToString().ToUpperInvariant();
@@ -471,19 +349,7 @@ namespace NScrape {
             return response;
         }
 
-	    /// <summary>
-		/// Gets or sets the user agent for requests made by a <see cref="WebClient"/>.
-	    /// </summary>
-	    /// <remarks>
-		/// If the user agent is not explicitly set, it defaults to a string of the form: <code>NScrape/[version] (+https://github.com/darrylwhitmore/NScrape)</code>
-	    /// </remarks>
-	    /// <example>
-	    /// <code>
-	    ///	var webClient = new WebClient {
-		///		UserAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko"
-		/// };
-	    /// </code>
-	    /// </example>
-		public string UserAgent { get; set; }
+        /// <include file='IWebClient.xml' path='/IWebClient/UserAgent'/>
+        public string UserAgent { get; set; }
 	}
 }

--- a/NScrape/XmlWebResponse.cs
+++ b/NScrape/XmlWebResponse.cs
@@ -8,7 +8,7 @@ namespace NScrape {
 	/// </summary>
 	public class XmlWebResponse : TextWebResponse {
 
-		internal XmlWebResponse( bool success, Uri url, string xml, Encoding encoding )
+		public XmlWebResponse( bool success, Uri url, string xml, Encoding encoding )
 			: base( url, WebResponseType.Xml, success, xml, encoding ) {
 			XDocument = XDocument.Parse( xml );
 		}


### PR DESCRIPTION
I've written some code that uses NScrape and would like to unit test it.

Currently, all code depends on the `WebClient`, which would mean my unit tests actually connect to the Internet and fetch the code. That's OK for integration tests, but not for unit tests.

This pull request adds a `IWebClient` interface, which enables you to mock the `WebClient` class, so you can validate the requests that are being sent and fake the responses that are being returned.

You could either implement the `IWebClient` interface yourself, or use a library like `Moq` to create a mock automatically.
