### PR TITLE
Add a ResponseReceived event to the WebClient class

### DIFF
--- a/NScrape/Forms/InputHtmlFormControl.cs
+++ b/NScrape/Forms/InputHtmlFormControl.cs
@@ -91,7 +91,7 @@ namespace NScrape.Forms {
         /// </returns>
         public override string ToString()
         {
-            return $"{this.Name}: {this.Value} ({this.ControlType})";
+            return string.Format("{0}: {1} ({2})", this.Name, this.Value, this.ControlType);
         }
     }
 }

--- a/NScrape/GetWebRequest.cs
+++ b/NScrape/GetWebRequest.cs
@@ -40,7 +40,7 @@ namespace NScrape {
         /// </returns>
         public override string ToString()
         {
-            return $"GET {this.Destination}";
+            return string.Format("GET {0}", this.Destination);
         }
     }
 }

--- a/NScrape/IWebClient.cs
+++ b/NScrape/IWebClient.cs
@@ -14,6 +14,9 @@ namespace NScrape
         /// <include file='IWebClient.xml' path='/IWebClient/SendingRequest'/>
         event EventHandler<SendingRequestEventArgs> SendingRequest;
 
+        /// <include file='IWebClient.xml' path='/IWebClient/ResponseReceived'/>
+        event EventHandler<ResponseReceivedEventArgs> ResponseReceived;
+
         /// <include file='IWebClient.xml' path='/IWebClient/CookieJar'/>
         CookieContainer CookieJar { get; }
 

--- a/NScrape/IWebClient.xml
+++ b/NScrape/IWebClient.xml
@@ -21,6 +21,15 @@
     <seealso cref="SendingRequestEventArgs"/>
   </SendingRequest>
 
+  <ResponseReceived>
+    <summary>
+      Occurs when a response has been received.
+    </summary>
+    <remarks>
+      Use this event to be notified when the <see cref="IWebClient"/> receives a response.
+    </remarks>
+  </ResponseReceived>
+  
   <CookieJar>
     <summary>
       Gets the cookies that have been collected by the <see cref="WebClient"/> in the course of executing requests.

--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -98,6 +98,7 @@
     <Compile Include="RegexCache.cs" />
     <Compile Include="ScrapeException.cs" />
     <Compile Include="Scraper.cs" />
+    <Compile Include="ResponseReceivedEventArgs.cs" />
     <Compile Include="SendingRequestEventArgs.cs" />
     <Compile Include="Forms\InputCheckBoxHtmlFormControl.cs" />
     <Compile Include="Forms\InputHtmlFormControlType.cs" />

--- a/NScrape/PostWebRequest.cs
+++ b/NScrape/PostWebRequest.cs
@@ -120,7 +120,7 @@ namespace NScrape {
         /// </returns>
         public override string ToString()
         {
-            return $"POST {this.Destination}";
+            return string.Format("POST {0}", this.Destination);
         }
     }
 }

--- a/NScrape/ResponseReceivedEventArgs.cs
+++ b/NScrape/ResponseReceivedEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Net;
+
+namespace NScrape {
+	/// <summary>
+	/// Provides data for the <see cref="WebClient.ResponseReceived"/> event.
+	/// </summary>
+	public class ResponseReceivedEventArgs : EventArgs {
+
+		internal ResponseReceivedEventArgs( HttpWebResponse response ) {
+            WebResponse = response;
+		}
+
+		/// <summary>
+		/// Gets the web response.
+		/// </summary>
+		/// <remarks>
+		/// Gets the web response that has been received from the server.
+		/// </remarks>
+		public HttpWebResponse WebResponse { get; private set; }
+	}
+}

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -19,6 +19,9 @@ namespace NScrape {
         /// <include file='IWebClient.xml' path='/IWebClient/SendingRequest'/>
         public event EventHandler<SendingRequestEventArgs> SendingRequest;
 
+        /// <include file='IWebClient.xml' path='/IWebClient/ResponseReceived'/>
+        public event EventHandler<ResponseReceivedEventArgs> ResponseReceived;
+
 	    private readonly HttpStatusCode[] redirectionStatusCodes = {
 		    HttpStatusCode.Moved,				// 301
 		    HttpStatusCode.MovedPermanently,	// 301
@@ -120,7 +123,23 @@ namespace NScrape {
 			}
 		}
 
-		private static string ReadResponseText( HttpWebResponse response, Encoding encoding ) {
+        /// <summary>
+        /// Raises the <see cref="ResponseReceived"/> event.
+        /// </summary>
+        /// <remarks>
+        /// Called when a response has been received.
+        /// </remarks>
+        /// <param name="args">A <see cref="ResponseReceivedEventArgs"/> that contains the event data.</param>
+        /// <seealso cref="SendingRequest"/>
+        protected virtual void OnResponseReceived(ResponseReceivedEventArgs args)
+        {
+            if (ResponseReceived != null)
+            {
+                ResponseReceived(this, args);
+            }
+        }
+
+        private static string ReadResponseText( HttpWebResponse response, Encoding encoding ) {
 			var s = response.GetResponseStream();
 
 			if ( s != null ) {
@@ -215,6 +234,8 @@ namespace NScrape {
 
             try {
                 var webResponse = ( HttpWebResponse )httpWebRequest.GetResponse();
+
+                OnResponseReceived( new ResponseReceivedEventArgs (webResponse ) );
 
                 if ( httpWebRequest.HaveResponse ) {
                     // Handle cookies that are offered

--- a/NScrape/WebResponseFactory.cs
+++ b/NScrape/WebResponseFactory.cs
@@ -19,6 +19,8 @@ namespace NScrape
         /// </summary>
         static WebResponseFactory()
         {
+            SupportedContentTypes = new Dictionary<string, Func<HttpWebResponse, WebResponse>>();
+
             SupportedContentTypes.Add("image/", CreateImageResponse);
             SupportedContentTypes.Add("text/xml", CreateXmlResponse);
             SupportedContentTypes.Add("application/xml", CreateXmlResponse);
@@ -27,8 +29,6 @@ namespace NScrape
             SupportedContentTypes.Add("application/javascript ", CreateJavaScriptResponse);
             SupportedContentTypes.Add("application/x-javascript", CreateJavaScriptResponse);
             SupportedContentTypes.Add("application/json", CreateJsonResponse);
-
-            SupportedContentTypes = new Dictionary<string, Func<HttpWebResponse, WebResponse>>();
         }
 
         /// <summary>


### PR DESCRIPTION
Hi Darryl,

I ended up in a situation where I had to parse the headers that were sent on a specific response, and add them to a subsequent request.

NScrape didn't give me access to the `HttpWebResponse` that was received, so I added a `ResponseReceived` event to the `WebClient` class. I can now subscribe to that event and manually extract the headers.

This pull request contains that change, plus a removal of the interpolated strings (they now cause a compiler error as the project compatibility has been set to C# 5) and a fix in the `WebResponseFactory` where a field would be initialized too late.

Hope it helps,

Frederik.
