### PR TITLE
Support binary (`application/octet-stream`) content

### DIFF
--- a/NScrape/BinaryWebResponse.cs
+++ b/NScrape/BinaryWebResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace NScrape {
+    /// <summary>
+	/// Represents a web response for a request that returned binary data.
+	/// </summary>
+    public class BinaryWebResponse : WebResponse {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryWebResponse"/> class.
+        /// </summary>
+        /// <param name="success"><b>true</b> if the response is considered successful, <b>false</b> otherwise.</param>
+        /// <param name="url">The URL of the response.</param>
+        /// <param name="data">The data that was returned by the web server.</param>
+        public BinaryWebResponse( bool success, Uri url, byte[] data )
+            : base( url, WebResponseType.Binary, success ) {
+            this.Data = data;
+        }
+
+        /// <summary>
+		/// Gets the binary data.
+		/// </summary>
+        public byte[] Data { get; private set; }
+    }
+}

--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -84,6 +84,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BinaryWebResponse.cs" />
     <Compile Include="CommonHeaders.cs" />
     <Compile Include="Forms\HtmlFormDefinition.cs" />
     <Compile Include="Forms\InputCheckableHtmlFormControl.cs" />

--- a/NScrape/WebResponseFactory.cs
+++ b/NScrape/WebResponseFactory.cs
@@ -100,6 +100,15 @@ namespace NScrape
             return new XmlWebResponse(true, webResponse.ResponseUri, xml, encoding);
         }
 
+        /// <summary>
+        /// Creates a <see cref="BinaryWebResponse"/>.
+        /// </summary>
+        /// <param name="webResponse">
+        /// The original <see cref="HttpWebResponse"/>.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="BinaryWebResponse"/>.
+        /// </returns>
         public static WebResponse CreateBinaryResponse(HttpWebResponse webResponse)
         {
             byte[] data = null;

--- a/NScrape/WebResponseFactory.cs
+++ b/NScrape/WebResponseFactory.cs
@@ -27,6 +27,7 @@ namespace NScrape
             SupportedContentTypes.Add("application/javascript ", CreateJavaScriptResponse);
             SupportedContentTypes.Add("application/x-javascript", CreateJavaScriptResponse);
             SupportedContentTypes.Add("application/json", CreateJsonResponse);
+            SupportedContentTypes.Add("application/octet-stream", CreateBinaryResponse);
 
             SupportedContentTypes = new Dictionary<string, Func<HttpWebResponse, WebResponse>>();
         }
@@ -97,6 +98,19 @@ namespace NScrape
             var encoding = GetEncoding(webResponse);
             var xml = ReadResponseText(webResponse, encoding);
             return new XmlWebResponse(true, webResponse.ResponseUri, xml, encoding);
+        }
+
+        public static WebResponse CreateBinaryResponse(HttpWebResponse webResponse)
+        {
+            byte[] data = null;
+
+            using (var s = webResponse.GetResponseStream())
+            using (BinaryReader reader = new BinaryReader(s))
+            {
+                reader.ReadBytes((int)s.Length);
+            }
+
+            return new BinaryWebResponse(true, webResponse.ResponseUri, data);
         }
 
         /// <summary>

--- a/NScrape/WebResponseFactory.cs
+++ b/NScrape/WebResponseFactory.cs
@@ -105,9 +105,10 @@ namespace NScrape
             byte[] data = null;
 
             using (var s = webResponse.GetResponseStream())
-            using (BinaryReader reader = new BinaryReader(s))
+            using (MemoryStream memoryStream = new MemoryStream())
             {
-                reader.ReadBytes((int)s.Length);
+                s.CopyTo(memoryStream);
+                data = memoryStream.ToArray();
             }
 
             return new BinaryWebResponse(true, webResponse.ResponseUri, data);

--- a/NScrape/WebResponseType.cs
+++ b/NScrape/WebResponseType.cs
@@ -41,6 +41,11 @@
 		/// <summary>
 		/// An XML reponse.
 		/// </summary>
-		Xml
+		Xml,
+
+		/// <summary>
+		/// An binary reponse.
+		/// </summary>
+		Binary
 	}
 }


### PR DESCRIPTION
Hi Darryl,

One more PR, this time to add for binary responses (of type `application/octet-stream`).
Should be pretty straightforward.

PS: I was wondering, do you plan to release a new version of the NuGet package any time soon?

Frederik.
