### PR TITLE
Expose the underlying `HttpWebResponse`

### DIFF
--- a/NScrape/IWebClient.cs
+++ b/NScrape/IWebClient.cs
@@ -32,6 +32,9 @@ namespace NScrape {
 		/// <include file='IWebClient.xml' path='/IWebClient/SendRequest_WebRequest/*'/>
 		WebResponse SendRequest( WebRequest webRequest );
 
+        /// <include file='IWebClient.xml' path='/IWebClient/GetHttpWebResponse/*'/>
+        HttpWebResponse GetHttpWebResponse (WebRequest webRequest);
+
 		/// <include file='IWebClient.xml' path='/IWebClient/UserAgent/*'/>
 		string UserAgent { get; set; }
 	}

--- a/NScrape/IWebClient.xml
+++ b/NScrape/IWebClient.xml
@@ -169,6 +169,19 @@
     <seealso cref="WebResponse"/>
   </SendRequest_WebRequest>
 
+  <GetHttpWebResponse>
+    <summary>
+      Sends a GET or POST request, reads the response, extracts the cookies (if any) and returns
+      a <see cref="HttpWebResponse"/> that represents the response.
+    </summary>
+    <param name="webRequest">The request to send.</param>
+    <returns>The native response from the server.</returns>
+    <remarks>
+      Only use this method if you want to parse the raw response received by the server. In most
+      cases, <see cref="SendRequest"/> is the preferred option.
+    </remarks>
+  </GetHttpWebResponse>
+  
   <UserAgent>
     <summary>
       Gets or sets the user agent for requests made by a <see cref="WebClient"/>.

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -159,81 +159,13 @@ namespace NScrape {
 
 		/// <include file='IWebClient.xml' path='/IWebClient/SendRequest_WebRequest/*'/>
         public WebResponse SendRequest( WebRequest webRequest ) {
-            var httpWebRequest = (HttpWebRequest)System.Net.WebRequest.Create( webRequest.Destination );
-
-			httpWebRequest.Method = webRequest.Type.ToString().ToUpperInvariant();
-
-			// We shall handle redirects by hand so that we may capture cookies and properly
-			// handle login forms.
-			//
-			// Automating Web Login With HttpWebRequest
-			// https://www.stevefenton.co.uk/Content/Blog/Date/201210/Blog/Automating-Web-Login-With-HttpWebRequest/
-			httpWebRequest.AllowAutoRedirect = false;
-
-			// Default headers.
-			httpWebRequest.Accept = "*/*";
-			httpWebRequest.UserAgent = UserAgent;
-
-			// Set and/or override any provided headers.
-	        foreach ( var headerName in webRequest.Headers.AllKeys ) {
-				ConfigureHeader( httpWebRequest, headerName, webRequest.Headers[headerName] );
-	        }
-
-            httpWebRequest.CookieContainer = new CookieContainer();
-            httpWebRequest.CookieContainer.Add( cookieJar.GetCookies( webRequest.Destination ) );
-            
-			if ( webRequest.Type == WebRequestType.Post ) {
-                var postRequest = (PostWebRequest)webRequest;
-
-                var requestDataBytes = Encoding.UTF8.GetBytes( postRequest.RequestData );
-                Stream requestStream = null;
-
-                httpWebRequest.ContentLength = requestDataBytes.Length;
-                httpWebRequest.ContentType = postRequest.ContentType;
-                httpWebRequest.ServicePoint.Expect100Continue = false;
-
-                try {
-                    requestStream = httpWebRequest.GetRequestStream();
-                    requestStream.Write( requestDataBytes, 0, requestDataBytes.Length );
-                }
-                finally {
-                    if ( requestStream != null ) {
-                        requestStream.Close();
-                    }
-                }
-            }
-
-			OnSendingRequest( new SendingRequestEventArgs( webRequest ) );
 
             WebResponse response;
-
             try {
-                var webResponse = ( HttpWebResponse )httpWebRequest.GetResponse();
+                // Will return null if no response is available.
+                var webResponse = GetHttpWebResponse(webRequest);
 
-                OnProcessingResponse( new ProcessingResponseEventArgs (webResponse ) );
-
-                if ( httpWebRequest.HaveResponse ) {
-                    // Handle cookies that are offered
-                    foreach ( Cookie responseCookie in webResponse.Cookies ) {
-                        var cookieFound = false;
-
-                        foreach ( Cookie existingCookie in cookieJar.GetCookies( webRequest.Destination ) ) {
-                            if ( responseCookie.Name.Equals( existingCookie.Name ) ) {
-                                existingCookie.Value = responseCookie.Value;
-                                cookieFound = true;
-                            }
-                        }
-
-                        if ( !cookieFound ) {
-                            var args = new AddingCookieEventArgs( responseCookie );
-
-                            OnAddingCookie( args );
-
-                            if ( !args.Cancel ) {
-                                cookieJar.Add( responseCookie );
-                            }
-                        }
-                    }
+                if ( webResponse != null ) {
 
 					if ( redirectionStatusCodes.Contains( webResponse.StatusCode ) ) {
 						// We have a redirected response.
@@ -288,8 +220,9 @@ namespace NScrape {
 									var redirectUri = new Uri( webResponse.ResponseUri, match.Groups[RegexLibrary.ParseMetaRefreshUrlGroup].Value );
 
 									if ( webRequest.AutoRedirect ) {
-										// We are auto redirecting, so make a recursive call to perform the redirect
-										response = SendRequest( new GetWebRequest( redirectUri, httpWebRequest.AllowAutoRedirect ) );
+                                        // We are auto redirecting, so make a recursive call to perform the redirect
+                                        // It appears httpWebRequest.AllowAutoRedirect = false was always set to false
+                                        response = SendRequest( new GetWebRequest( redirectUri, false ) );
 									}
 									else {
 										// We are not auto redirecting, so send the caller a redirect response
@@ -322,5 +255,99 @@ namespace NScrape {
 
 		/// <include file='IWebClient.xml' path='/IWebClient/UserAgent/*'/>
         public string UserAgent { get; set; }
-	}
+
+        /// <include file='IWebClient.xml' path='/IWebClient/GetHttpWebResponse/*'/>
+        public HttpWebResponse GetHttpWebResponse (WebRequest webRequest)
+        {
+            var httpWebRequest = (HttpWebRequest)System.Net.WebRequest.Create(webRequest.Destination);
+            httpWebRequest.Method = webRequest.Type.ToString().ToUpperInvariant();
+
+            // We shall handle redirects by hand so that we may capture cookies and properly
+            // handle login forms.
+            //
+            // Automating Web Login With HttpWebRequest
+            // https://www.stevefenton.co.uk/Content/Blog/Date/201210/Blog/Automating-Web-Login-With-HttpWebRequest/
+            httpWebRequest.AllowAutoRedirect = false;
+
+            // Default headers.
+            httpWebRequest.Accept = "*/*";
+            httpWebRequest.UserAgent = UserAgent;
+
+            // Set and/or override any provided headers.
+            foreach (var headerName in webRequest.Headers.AllKeys)
+            {
+                ConfigureHeader(httpWebRequest, headerName, webRequest.Headers[headerName]);
+            }
+
+            httpWebRequest.CookieContainer = new CookieContainer();
+            httpWebRequest.CookieContainer.Add(cookieJar.GetCookies(webRequest.Destination));
+
+            if (webRequest.Type == WebRequestType.Post)
+            {
+                var postRequest = (PostWebRequest)webRequest;
+
+                var requestDataBytes = Encoding.UTF8.GetBytes(postRequest.RequestData);
+                Stream requestStream = null;
+
+                httpWebRequest.ContentLength = requestDataBytes.Length;
+                httpWebRequest.ContentType = postRequest.ContentType;
+                httpWebRequest.ServicePoint.Expect100Continue = false;
+
+                try
+                {
+                    requestStream = httpWebRequest.GetRequestStream();
+                    requestStream.Write(requestDataBytes, 0, requestDataBytes.Length);
+                }
+                finally
+                {
+                    if (requestStream != null)
+                    {
+                        requestStream.Close();
+                    }
+                }
+            }
+
+            OnSendingRequest(new SendingRequestEventArgs(webRequest));
+
+            var webResponse = (HttpWebResponse)httpWebRequest.GetResponse();
+
+            OnProcessingResponse(new ProcessingResponseEventArgs(webResponse));
+
+            if (httpWebRequest.HaveResponse)
+            {
+                // Handle cookies that are offered
+                foreach (Cookie responseCookie in webResponse.Cookies)
+                {
+                    var cookieFound = false;
+
+                    foreach (Cookie existingCookie in cookieJar.GetCookies(webRequest.Destination))
+                    {
+                        if (responseCookie.Name.Equals(existingCookie.Name))
+                        {
+                            existingCookie.Value = responseCookie.Value;
+                            cookieFound = true;
+                        }
+                    }
+
+                    if (!cookieFound)
+                    {
+                        var args = new AddingCookieEventArgs(responseCookie);
+
+                        OnAddingCookie(args);
+
+                        if (!args.Cancel)
+                        {
+                            cookieJar.Add(responseCookie);
+                        }
+                    }
+                }
+
+                return webResponse;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hi @darrylwhitmore,

Me again ;-)

So, I came across this scenario: 
- Log in to a website
- Navigate a couple of forms
- Download a large file (4,4 GB)

In its current configuration, NScrape would create a `BinaryWebResponse` which reads the entire response using a `MemoryStream` and stores it in a byte array. At 4,4 GB, that makes for some heavy memory usage.

Initially I thought an option could be to have the BinaryWebResponse expose the underlying `ResponseStream`, but in that case the web responses would need to implement `IDisposable` and it seems that's not quite how they were intended to work.

So what I came up with for now, is to add a method that allows callers of `WebClient` to fetch the actual `HttpWebResponse` if they want to do so.

It's kind of an escape hatch, I know, but currently can't think of a better way.

Let me know if this works for you, or whether you see an alternative.

Thanks!

Frederik.
