### PR TITLE
Fix cookie handling

### DIFF
--- a/NScrape/BinaryWebResponse.cs
+++ b/NScrape/BinaryWebResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 
 namespace NScrape {
@@ -34,6 +35,17 @@ namespace NScrape {
 			: base( success, webResponse.ResponseUri, WebResponseType.Binary ) {
 			this.webResponse = webResponse;
 		}
+
+        /// <summary>
+        /// Gets the length of the content returned by the request.
+        /// </summary>
+        public long ContentLength
+        {
+            get
+            {
+                return this.webResponse.ContentLength;
+            }
+        }
 
 		/// <summary>
 		/// Closes the binary response stream.

--- a/NScrape/CookieParser.cs
+++ b/NScrape/CookieParser.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+
+namespace NScrape
+{
+    /// <summary>
+    /// Provides methods for parsing the value of the <c>Set-Cookie</c> header. The standard .NET WebResponse class does not correctly parse all cookies;
+    /// this class tries to correct that.
+    /// </summary>
+    /// <seealso href="http://stackoverflow.com/questions/15103513/httpwebresponse-cookies-empty-despite-set-cookie-header-no-redirect"/>
+    public static class CookieParser
+    {
+        /// <summary>
+        /// Extracts a <see cref="CookieCollection"/> from a <c>Set-Cookie</c> header.
+        /// </summary>
+        /// <param name="setCookieHeader">
+        /// The value of the <c>Set-Cookie</c> header.
+        /// </param>
+        /// <param name="hostName">
+        /// The host name of the server to which the request was sent. Cookies will be scoped to this host name, unless otherwise
+        /// specified in the <c>Set-Cookie</c> declaration.
+        /// </param>
+        /// <returns>
+        /// A <see cref="CookieCollection"/> which represents the list of cookies which have been extracted.
+        /// </returns>
+        public static CookieCollection GetAllCookiesFromHeader(string setCookieHeader, string hostName)
+        {
+            CookieCollection cookies = new CookieCollection();
+
+            if (setCookieHeader != string.Empty)
+            {
+                var cookieLines = ExtractCookieDeclarations(setCookieHeader);
+                cookies = ConvertCookieDeclarationsToCookieCollection(cookieLines, hostName);
+            }
+
+            return cookies;
+        }
+
+
+        /// <summary>
+        /// Splits the <c>Set-Cookie</c> hierder into the individual strings that define a cookie. Corrects for lines that contain an expiry
+        /// date which include a <c>,</c> in the expires value - such as <c>Expires=Tue, 03 May 2016 14:35:28 GMT</c>
+        /// </summary>
+        /// <param name="setCookieHeader"></param>
+        /// <returns></returns>
+        public static Collection<string> ExtractCookieDeclarations(string setCookieHeader)
+        {
+            // Remove any new line character
+            setCookieHeader = setCookieHeader.Replace("\r", "");
+            setCookieHeader = setCookieHeader.Replace("\n", "");
+
+            // Split on the ',' sign
+            string[] setCookieParts = setCookieHeader.Split(',');
+
+            Collection<string> cookieLines = new Collection<string>();
+            int i = 0;
+            int n = setCookieParts.Length;
+
+            while (i < n)
+            {
+                // Correct for the expires field, which can include a comma
+                if (setCookieParts[i].IndexOf("expires=", StringComparison.OrdinalIgnoreCase) > 0)
+                {
+                    cookieLines.Add(setCookieParts[i] + "," + setCookieParts[i + 1]);
+                    i++;
+                }
+                else
+                {
+                    cookieLines.Add(setCookieParts[i]);
+                }
+                i++;
+            }
+
+            return cookieLines;
+        }
+
+        /// <summary>
+        /// Converts a set of cookie declarations to a <see cref="CookieCollection"/>.
+        /// </summary>
+        /// <param name="cookieDeclarations">
+        /// The cookie declarations to parse.
+        /// </param>
+        /// <param name="hostName">
+        /// The hostname of the server which issued the cookies.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="CookieCollection"/></returns>
+        public static CookieCollection ConvertCookieDeclarationsToCookieCollection(Collection<string> cookieDeclarations, string hostName)
+        {
+            CookieCollection cookieCollection = new CookieCollection();
+
+            foreach (var cookieDeclaration in cookieDeclarations)
+            {
+                var cookieParts = cookieDeclaration.Split(';');
+
+                Cookie cookie = new Cookie();
+                cookie.Path = "/";
+                cookie.Domain = hostName;
+
+                bool hasMaxAge = false;
+
+                // At index 0, we'll have the name of the cookie
+                var cookieNameAndValue = cookieParts[0];
+
+                if (cookieNameAndValue != string.Empty)
+                {
+                    int firstEqual = cookieNameAndValue.IndexOf("=");
+                    string firstName = cookieNameAndValue.Substring(0, firstEqual);
+                    string allValue = cookieNameAndValue.Substring(firstEqual + 1, cookieNameAndValue.Length - (firstEqual + 1));
+                    cookie.Name = firstName;
+                    cookie.Value = allValue;
+                }
+
+                foreach (var cookiePart in cookieParts.Skip(1))
+                {
+                    var pair = cookiePart.Split(new char[] { '=' }, 2);
+
+                    if (pair.Length == 1)
+                    {
+                        if (string.Equals(pair[0], "httponly", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            cookie.HttpOnly = true;
+                        }
+                        else if (string.Equals(pair[0], "secure", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            cookie.Secure = true;
+                        }
+                    }
+                    else
+                    {
+                        if (string.Equals(pair[0], "path", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            if (pair[1] != string.Empty)
+                            {
+                                cookie.Path = pair[1];
+                            }
+                            else
+                            {
+                                cookie.Path = "/";
+                            }
+                        }
+                        else if (string.Equals(pair[0], "domain", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            if (pair[1] != string.Empty)
+                            {
+                                cookie.Domain = pair[1];
+                            }
+                            else
+                            {
+                                cookie.Domain = hostName;
+                            }
+                        }
+                        else if (string.Equals(pair[0], "max-age", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            var maxAge = int.Parse(pair[1]);
+                            cookie.Expires = DateTime.Now.AddSeconds(maxAge);
+
+                            // Prevent the 'expires' value from overriding the value that was determined using max-age
+                            hasMaxAge = true;
+                        }
+                        else if (!hasMaxAge && string.Equals(pair[0], "expires", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            // max-age takes precedence over "expires"
+                            cookie.Expires = DateTime.ParseExact(pair[1], "r", null).ToLocalTime();
+                        }
+                    }
+                }
+
+                cookieCollection.Add(cookie);
+            }
+
+            return cookieCollection;
+        }
+    }
+}

--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <Compile Include="BinaryWebResponse.cs" />
     <Compile Include="CommonHeaders.cs" />
+    <Compile Include="CookieParser.cs" />
     <Compile Include="Forms\HtmlFormDefinition.cs" />
     <Compile Include="Forms\InputCheckableHtmlFormControl.cs" />
     <Compile Include="Forms\BasicAspxForm.cs" />

--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -86,7 +86,7 @@
   <ItemGroup>
     <Compile Include="BinaryWebResponse.cs" />
     <Compile Include="CommonHeaders.cs" />
-    <Compile Include="CookieParser.cs" />
+    <Compile Include="CookieCollectionExtensions.cs" />
     <Compile Include="Forms\HtmlFormDefinition.cs" />
     <Compile Include="Forms\InputCheckableHtmlFormControl.cs" />
     <Compile Include="Forms\BasicAspxForm.cs" />

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -230,8 +230,32 @@ namespace NScrape {
 	            OnProcessingResponse( new ProcessingResponseEventArgs( webResponse ) );
 
                 if ( httpWebRequest.HaveResponse ) {
+                    // Process cookies that the .NET client 'forgot' to include,
+                    // see http://stackoverflow.com/questions/15103513/httpwebresponse-cookies-empty-despite-set-cookie-header-no-redirect
+                    // for more details;
+                    // an example cookie which is not parsed is this one:
+                    //
+                    // Set-Cookie:ADCDownloadAuth=[long token];Version=1;Comment=;Domain=apple.com;Path=/;Max-Age=108000;HttpOnly;Expires=Tue, 03 May 2016 13:30:57 GMT
+
                     // Handle cookies that are offered
-                    foreach ( Cookie responseCookie in webResponse.Cookies ) {
+                    CookieCollection cookies = new CookieCollection();
+                    cookies.Add(webResponse.Cookies);
+
+                    if (webResponse.Headers.AllKeys.Contains("Set-Cookie"))
+                    {
+                        var alternateCookies = CookieParser.GetAllCookiesFromHeader(webResponse.Headers["Set-Cookie"], httpWebRequest.Host);
+
+                        foreach (Cookie alternateCookie in alternateCookies)
+                        {
+                            // Match cookies by name, and only add the cookie if it was not found previously
+                            if (!cookies.OfType<Cookie>().Any(c => c.Name == alternateCookie.Name))
+                            {
+                                cookies.Add(alternateCookie);
+                            }
+                        }
+                    }
+
+                    foreach ( Cookie responseCookie in cookies ) {
                         var cookieFound = false;
 
                         foreach ( Cookie existingCookie in cookieJar.GetCookies( webRequest.Destination ) ) {

--- a/NScrape/WebClient.cs
+++ b/NScrape/WebClient.cs
@@ -243,16 +243,7 @@ namespace NScrape {
 
                     if (webResponse.Headers.AllKeys.Contains("Set-Cookie"))
                     {
-                        var alternateCookies = CookieParser.GetAllCookiesFromHeader(webResponse.Headers["Set-Cookie"], httpWebRequest.Host);
-
-                        foreach (Cookie alternateCookie in alternateCookies)
-                        {
-                            // Match cookies by name, and only add the cookie if it was not found previously
-                            if (!cookies.OfType<Cookie>().Any(c => c.Name == alternateCookie.Name))
-                            {
-                                cookies.Add(alternateCookie);
-                            }
-                        }
+                        cookies.Parse(webResponse.Headers["Set-Cookie"], httpWebRequest.Host);
                     }
 
                     foreach ( Cookie responseCookie in cookies ) {


### PR DESCRIPTION
Hi @darrylwhitmore ,

I stumbled upon an issue where .NET does not correctly parse the Set-Cookie header. This was really annoying for me, as it was a security cookie that prevented me from going further.
(There are a couple of discussions on StackOverflow regarding this, see e.g. http://stackoverflow.com/questions/15103513/httpwebresponse-cookies-empty-despite-set-cookie-header-no-redirect).

If that logic identifies any cookie that was not found by .NET, it is added automatically to the cookie collection. Otherwise, the cookie is left untouched.

At the same time, I also took the chance to add a `ContentLength` property to the `BinaryWebResponse` class - may be handy to know how much data is being thrown at you :-).

Let me know if this works for you,

Frederik.
