### PR TITLE
Bump HtmlAgilityPack version

### DIFF
--- a/NScrape/NScrape.Core.csproj
+++ b/NScrape/NScrape.Core.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <AssemblyName>CoreCompat.NScrape</AssemblyName>
     <PackageId>CoreCompat.NScrape</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.5' ">$(PackageTargetFallback);portable-net45</PackageTargetFallback>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     
     <!-- NuGet package properties -->
@@ -24,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.5.1" />
     <PackageReference Include="Sprache" Version="2.1.0" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,3 @@
-before_build:
-  - cmd: choco install wget
-  - wget -q https://download.microsoft.com/download/8/F/9/8F9659B9-E628-4D1A-B6BF-C3004C8C954B/dotnet-1.1.1-sdk-win-x64.exe
-  - dotnet-1.1.1-sdk-win-x64.exe /install /quiet /log dotnetinstall.log
-  - ps: Push-AppveyorArtifact "dotnetinstall.log"
-
 build_script:
   - cmd: cd NScrape
   - cmd: dotnet restore NScrape.Core.csproj


### PR DESCRIPTION
Version 1.5.1 of the HtmlAgilityPack was released which now provides native support for .NET Core, so use that version.
AppVeyor now includes .NET Core by default, so no need to download .NET Core.