### PR TITLE
Use System.Drawing.Common on netcoreapp

### DIFF
--- a/NScrape/NScrape.Core.csproj
+++ b/NScrape/NScrape.Core.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <VersionPrefix>0.4.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netcoreapp2.0;net45</TargetFrameworks>
     <AssemblyName>CoreCompat.NScrape</AssemblyName>
     <PackageId>CoreCompat.NScrape</PackageId>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    
+
     <!-- NuGet package properties -->
     <Description>A web scraping framework for .Net</Description>
     <Authors>Darryl G. Whitmore</Authors>
@@ -38,6 +38,10 @@
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview1-25718-03"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Microsoft is bringing back System.Drawing to .NET Core, so for applications targeting .NET Core, it's better to reference System.Drawing.Common than CoreCompat.System.Drawing.