### PR TITLE
Use a released version of System.Drawing.Common

### DIFF
--- a/NScrape/NScrape.csproj
+++ b/NScrape/NScrape.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.7.2" />
     <PackageReference Include="Sprache.Signed" Version="2.1.2" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview1-26216-02" />
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR bumps the dependency on `System.Drawing.Common` from `4.5.0-preview1-26216-02` to `4.5.0`.
It's not a functional change; the only reason is to avoid having a dependency on a pre-release package.